### PR TITLE
Fix running interproscan

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ By default, the pipeline uses the provided test data set as raw input data,
 this can be changed by updating the input paths in the provided config.yaml.
 Filtering parameters, output paths and scratch directory can also be altered.
 
+### Install InterProScan
+InterProScan is required for the functional annotation step which is enabled by using the `functions:` field in the `config.yaml`.
+Please follow the instructions on the [InterProScan website](https://interproscan-docs.readthedocs.io/en/v5/HowToDownload.html) to install InterProScan.
+
 ## Input data
 Two input directories are required. One with genomic fasta files and one with matching annotations.
 All fasta files must end in *.fna*, all annotations files in *.gff*. 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ InterProScan is required for the functional annotation step which is enabled by 
 Please follow the instructions on the [InterProScan website](https://interproscan-docs.readthedocs.io/en/v5/HowToDownload.html) to install InterProScan.
 You can test if InterProScan is installed correctly by running the following command:
 ```bash
-interproscan.sh -h
+interproscan.sh --help
 ``````
 
 ## Input data

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Filtering parameters, output paths and scratch directory can also be altered.
 ### Install InterProScan
 InterProScan is required for the functional annotation step which is enabled by using the `functions:` field in the `config.yaml`.
 Please follow the instructions on the [InterProScan website](https://interproscan-docs.readthedocs.io/en/v5/HowToDownload.html) to install InterProScan.
+You can test if InterProScan is installed correctly by running the following command:
+```bash
+interproscan.sh -h
+``````
 
 ## Input data
 Two input directories are required. One with genomic fasta files and one with matching annotations.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,7 +17,7 @@ scratch:
 filtered_genomes: results/genomes_filtered
 filtered_annotations: results/annotations_filtered
 proteins: results/proteins
-functions: results/functions
+functions: results/functions  #remove output directory when no functions should be run
 statistics: results/statistics
 metadata: results/metadata
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -8,10 +8,10 @@ include: 'rules/statistics.smk'
 include: 'rules/locations.smk'
 
 def get_function_locations(wildcards):
-    if "functions" in config and config["functions"]:
-        return f"{config['metadata']}/function_locations.txt"
-    else:
-        return ""
+    filelist = []
+    if config["functions"]:
+        filelist.append(f"{config['metadata']}/function_locations.txt")
+    return filelist
 
 rule all:
     input:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -7,6 +7,12 @@ include: 'rules/functions.smk'
 include: 'rules/statistics.smk'
 include: 'rules/locations.smk'
 
+def get_function_locations(wildcards):
+    if "functions" in config and config["functions"]:
+        return f"{config['metadata']}/function_locations.txt"
+    else:
+        return ""
+
 rule all:
     input:
         f"{config['statistics']}/genome_contents_raw.tsv",
@@ -19,7 +25,7 @@ rule all:
         f"{config['metadata']}/annotation_locations.txt",
         f"{config['statistics']}/protein_contents_filtered.tsv",
         f"{config['metadata']}/protein_locations.txt",
-        #f"{config['metadata']}/function_locations.txt"
+        get_function_locations,
 
 rule raw_statistics:
     input:
@@ -42,4 +48,4 @@ rule proteins:
 
 rule functions:
     input:
-        f"{config['metadata']}/function_locations.txt"
+        get_function_locations,

--- a/workflow/envs/interproscan.yaml
+++ b/workflow/envs/interproscan.yaml
@@ -1,5 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda
-dependencies:
-  - interproscan=5.59_91.0

--- a/workflow/rules/functions.smk
+++ b/workflow/rules/functions.smk
@@ -23,5 +23,5 @@ rule interproscan:
             -i {input.proteins} \
             -o {output} \
             --cpu {threads} \
-            -T {scratch}/interproscan > {log}
+            -T {scratch}/interproscan_{wildcards.annotation_name} > {log}
         """

--- a/workflow/rules/functions.smk
+++ b/workflow/rules/functions.smk
@@ -1,23 +1,8 @@
-rule interproscan_setup:
-    """
-    Download the interproscan database into the conda environment to scan against.
-    """
-    output:
-        touch(".snakemake/metadata/interproscan_setup.done")
-    conda:
-        "../envs/interproscan.yaml"
-    shell:
-        """
-        cd $CONDA_PREFIX/share/InterProScan/
-        python3 setup.py -f interproscan.properties
-        """
-
 rule interproscan:
     """
     Create functional annotations using InterProScan.
     """
     input:
-        ".snakemake/metadata/interproscan_setup.done",
         proteins = f"{config['proteins']}/{{annotation_name}}.filtered.pep.faa"
     output:
         f"{config['functions']}/{{annotation_name}}.interproscan.gff"
@@ -25,12 +10,11 @@ rule interproscan:
         appl = config['applications']
     threads:
         max(workflow.cores / len(data.annotation), 1)
-    conda:
-        "../envs/interproscan.yaml"
     log:
         f"{config['functions']}/logs/{{annotation_name}}.interproscan.log"
     shell:
         """
+        command -v interproscan.sh > /dev/null 2>&1 || {{ echo >&2 "ERROR: 'interproscan.sh' is required but it's not installed. Aborting."; exit 1; }}
         interproscan.sh \
             -f gff3 \
             --appl {params.appl} \


### PR DESCRIPTION
As mentioned in #6, interproscan does not work when installed through bioconda. Therefore, we need to have another way of running interproscan. With this PR, we will require the user to install interproscan manually before the pipeline is started. Alternatively, when the `functions` field of the `config.yaml` is left empty, no functional annotation will be run.