### PR TITLE
Update AGAT

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -29,7 +29,7 @@ min_len: 1000
 # only keep features of longest isoform
 longest_isoform: False
 
-# minimum size of the CDS open reading frame
+# minimum size of the CDS open reading frame (length in amino acids)
 orf_size: 30
 
 # comma separated list of InterProScan analyses

--- a/workflow/envs/agat.yaml
+++ b/workflow/envs/agat.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - agat=1.2.0
+  - agat=1.4.2

--- a/workflow/envs/agat.yaml
+++ b/workflow/envs/agat.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - agat=1.4.2
+  - agat=1.5.0


### PR DESCRIPTION
We noticed that the protein length filter (called `orf_size` in the `config/config.yaml`) did not always work as expected: sometimes smaller proteins would still exist after filtering. It turned out that this occured when a gene has multiple transcripts of which some where smaller and some longer than the threshold, the gene with all its transcripts would be kept. This strange behaviour has been fixed with the release of AGAT v1.5.0 and now individual transcripts are filtered instead of genes based on their protein length (resulting from CDS).