### PR TITLE
Changed script to handle na-values in agat-output

### DIFF
--- a/workflow/scripts/combine_statistics.py
+++ b/workflow/scripts/combine_statistics.py
@@ -24,6 +24,9 @@ if __name__ == "__main__":
                     continue
                 if values[0] not in stats:
                     stats[values[0]] = np.zeros(len(snakemake.input))
+                if values[1] == 'na':
+                    values[1] = float("NaN")
+
                 stats[values[0]][i] = values[1]
 
     # write values to csv


### PR DESCRIPTION
It appears that AGAT creates output files which contain features that have no values. This value is stored as 'na', which python cannot handle by default.

Added a line in the 'combine-statistics' python script which checks for this literal-string, and converts it into a python-parseable string indicating NaN.